### PR TITLE
allow for non-package specific webpack imports

### DIFF
--- a/api/v1/index.js
+++ b/api/v1/index.js
@@ -1,4 +1,4 @@
 module.exports = {
-  chain: require('./chain'),
-  account_history: require('./account_history')
+  chain: require('./chain.json'),
+  account_history: require('./account_history.json')
 }

--- a/schema/index.js
+++ b/schema/index.js
@@ -1,4 +1,4 @@
-const base = require('./base')
-const generated = require('./generated')
+const base = require('./base.json')
+const generated = require('./generated.json')
 
 module.exports = Object.assign({}, base, generated)


### PR DESCRIPTION
Some webpack configs want all requires to have extensions for non javascript ( .js ) files or the build fails.